### PR TITLE
Added feed-io to the list

### DIFF
--- a/pages/code.markdown
+++ b/pages/code.markdown
@@ -19,6 +19,7 @@
 * [RSS/Atom to JSON Feed converter](https://github.com/appsattic/feed2json.org) and [web service](https://feed2json.org) by Andrew Chilton
 * [PHP JSON Feed Generator](https://github.com/mateusjatenee/php-json-feed) by Mateus Guimarães
 * [PHP JSONFeed library](https://github.com/jdecool/jsonfeed) by Jérémy DECOOL
+* [PHP feed-io library](https://feed-io.net) by Alexandre Debril
 * [Metalsmith plugin](https://github.com/bensmithett/metalsmith-json-feed) by Ben Smithett
 * [Pelican plugin](https://github.com/andrewheiss/pelican_json_feed) by Andrew Heiss
 * [Pelican feed template](https://github.com/andrewheiss/athpelican/blob/master/theme/templates/feed.json) by Andrew Heiss


### PR DESCRIPTION
Hi,

feed-io is a PHP library built to read and write RSS and Atom feeds. I recently added JSON Feed support to it.

Thank you in advance for merging this