### PR TITLE
Add item authors to spec

### DIFF
--- a/pages/version/1.markdown
+++ b/pages/version/1.markdown
@@ -111,7 +111,7 @@ After that there’s an array of objects — `items` — that describe each obj
 
 * `date_modified` (optional, string) specifies the modification date in RFC 3339 format.
 
-* `author` (optional, object) has the same structure as the top-level `author`. If not specified in an item, then the top-level `author`, if present, is the author of the item.
+* `authors` (optional, array of objects) or `author` (optional, object) specifies the item author(s). Each object is the same structure as the top-level `author`. If `authors` and `author` are not specified in an item, then the top-level `author`, if present, is the author of the item. If both `authors` and `author` are specified in an item, `author` is ignored.
 
 * `tags` (optional, array of strings) can have any plain text values you want. Tags tend to be just one word, but they may be anything. Note: they are not the equivalent of Twitter hashtags. Some blogging systems and other feed formats call these categories.
 


### PR DESCRIPTION
It is common for articles or podcasts to have multiple authors.
Examples include The New York Times and The New Yorker:

https://github.com/brentsimmons/JSONFeed/issues/6

Currently, the JSON feed spec allows one `author` object
on the top-level feed and one on each item:

```json
author: {
  name: "Alice",
  url: "https://example.org/alice",
  avatar: "https://example.org/alice.png",
}
```

To provide an item with multiple authors,
the author names could be concatenated and URLs and avatars removed:

```json
author: {
  name: "Alice and Bob",
}
```

Or, the author names could be concatenated
and combined URLs and avatars provided:

```json
author: {
  name: "Alice and Bob",
  url: "https://example.org/alice-and-bob",
  avatar: "https://example.org/alice-and-bob.png",
}
```

Those use cases might work well when the author is a team:

```json
author: {
  name: "Engineering Team",
  url: "https://example.org/team/engineering",
  avatar: "https://example.org/team/engineering.png",
}
```

This feels more awkward for use cases of blog posts / news articles
with multiple authors, or podcasts with multiple hosts where
the publisher wants to provide links for each author's individual
identity, such as to a listing of that author's other works.

In those cases, this structure feels nice to me:

```json
authors: [
  {
    name: "Alice",
    url: "https://example.org/alice",
  },
  {
    name: "Bob",
    url: "https://example.org/bob",
  }
]
```

I can imagine a natural-looking feed reader experience of:

```
Article Title
by Alice and Bob
May 6, 2018
```

This change adds `authors` to `items` and attempts to make it clear
to implementers how to handle the various present/missing states
for `author` and `authors`. Although all use cases can be covered by the
`authors` array (single author items can be modeled as a one item array),
it does not deprecate `author`. I leave that decision to project maintainers.

Also, this change does not add `authors` to the top-level feed.
In my experience, even on publications with multiple authors per item,
the top-level feed `author` has appropriately been the publishing
company or organization.