### PR TITLE
Add JSON Feed to RSS converter (Apple podcast support)

### DIFF
--- a/pages/code.markdown
+++ b/pages/code.markdown
@@ -26,6 +26,7 @@
 * [C# parsing & generator library](https://github.com/DanRigby/JsonFeed.NET) by Dan Rigby
 * [Crystal parser & generator library](https://github.com/DougEverly/jsonfeed.cr) by Doug Everly
 * [JS JSON Feed to Atom converter](https://github.com/bcomnes/jsonfeed-to-atom) by Bret Comnes
+* [JS JSON Feed to RSS converter](https://github.com/bcomnes/jsonfeed-to-rss) (with full Apple Podcast support) by Bret Comnes
 
 
 As more code is published, by us and others, we’ll add to this page.


### PR DESCRIPTION
After going down the jsonfeed-to-atom path, I realized, despite Atom being a much cleaner format and serialization, apple chose side with RSS, so I implemented an RSS converter and included full apple podcast extension support.  This should enable people to publish podcasts with JSON Feed and easily convert them into an Apple podcast compatible feed, perhaps helping justify going down the json feed route in the first place.