### PR TITLE
Add link to TypeScript types

### DIFF
--- a/pages/code.markdown
+++ b/pages/code.markdown
@@ -35,5 +35,6 @@
 * [JS JSON Feed to RSS converter](https://github.com/bcomnes/jsonfeed-to-rss) (with full Apple Podcast support) by Bret Comnes
 * [Perl5 JSON::Feed parser and generator](https://metacpan.org/pod/JSON::Feed) by Kang-min Liu
 * [Eleventy plugin](https://www.npmjs.com/package/eleventy-plugin-json-feed) by John SJ Anderson
+* [TypeScript types](https://github.com/juice49/json-feed-types) by Ash
 
 As more code is published, by us and others, we’ll add to this page.


### PR DESCRIPTION
I created TypeScript types based on the JSON Feed 1.1 spec. These will help folks make sure their feed adheres to the spec, and provide helpful annotations in text editors such as VS Code.

https://github.com/juice49/json-feed-types

Thanks for creating JSON Feed 🙂.